### PR TITLE
Remove use of l0-path-constraints

### DIFF
--- a/ietf-flexi-grid-path-computation.yang
+++ b/ietf-flexi-grid-path-computation.yang
@@ -63,7 +63,7 @@ module ietf-flexi-grid-path-computation {
     This version of this YANG module is part of RFC XXXX; see
     the RFC itself for full legal notices.";
 
-  revision "2021-10-15" {
+  revision "2021-12-20" {
     description
       "Initial version.";
     reference
@@ -82,7 +82,6 @@ module ietf-flexi-grid-path-computation {
        "Augment with additional constraints flexi-grid
         media channel.";
     uses l0-types-ext:l0-tunnel-attributes;
-    uses l0-types-ext:l0-path-constraints;
   }
 
   /*

--- a/ietf-wson-path-computation.yang
+++ b/ietf-wson-path-computation.yang
@@ -62,7 +62,7 @@ module ietf-wson-path-computation {
     This version of this YANG module is part of RFC XXXX; see
     the RFC itself for full legal notices.";
 
-  revision "2021-10-15" {
+  revision "2021-12-20" {
     description
       "Initial version.";
     reference
@@ -80,7 +80,6 @@ module ietf-wson-path-computation {
     description
        "Augment with additional constraints for WSON paths.";
     uses l0-types-ext:l0-tunnel-attributes;
-    uses l0-types-ext:l0-path-constraints;
   }
 
   /*


### PR DESCRIPTION
Remove the use of l0-path-constraints grouping from l0-type-ext

Fix https://github.com/ietf-ccamp-wg/draft-ietf-ccamp-flexigrid-tunnel-yang/issues/16

Pending merge of https://github.com/ietf-ccamp-wg/ietf-ccamp-layer0-types-ext/pull/31

Co-Authored-By: sergio belotti <sergio.belotti@nokia.com>
